### PR TITLE
Fix ALLOWED_HOSTS environment variable parsing

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -13,7 +13,7 @@ SECRET_KEY = os.getenv(
 
 DEBUG = os.getenv("DJANGO_DEBUG", True)
 
-ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", ["*"])
+ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", ["*"]).split(",")
 
 DJANGO_APPS = [
     "django.contrib.auth",


### PR DESCRIPTION
Correctly split and handle the `ALLOWED_HOSTS` environment variable in `settings.py`, ensuring proper configuration for allowed hosts in the application.